### PR TITLE
chore(pokecache): upgrade to use stdlib context

### DIFF
--- a/internal/command/callbacks/common.go
+++ b/internal/command/callbacks/common.go
@@ -1,17 +1,18 @@
 package callbacks
 
 import (
-	"github.com/chrxn1c/pokemon-repl/internal/user_context"
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/chrxn1c/pokemon-repl/internal/user_context"
 )
 
 func makeAPIRequestAndProcessErrors(ctx *user_context.UserContext, currentURL string) (body []byte, err error) {
 
-	cachedResponse, isCached := ctx.Cache.Get(currentURL)
-	if isCached {
-		return cachedResponse, nil
+	cached := ctx.Cache.Get(currentURL)
+	if cached != nil {
+		return cached, nil
 	}
 
 	response, err := http.Get(currentURL)

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -2,9 +2,10 @@ package application
 
 import (
 	"fmt"
-	"github.com/chrxn1c/pokemon-repl/internal/pokecache"
 	"testing"
 	"time"
+
+	"github.com/chrxn1c/pokemon-repl/internal/pokecache"
 )
 
 func TestAddGet(t *testing.T) {
@@ -27,8 +28,8 @@ func TestAddGet(t *testing.T) {
 		t.Run(fmt.Sprintf("Test case %v", i), func(t *testing.T) {
 			cache := pokecache.NewCache(interval)
 			cache.Add(c.key, c.value)
-			val, ok := cache.Get(c.key)
-			if !ok {
+			val := cache.Get(c.key)
+			if val == nil {
 				t.Errorf("expected to find key")
 				return
 			}
@@ -46,16 +47,16 @@ func TestReapLoop(t *testing.T) {
 	cache := pokecache.NewCache(baseTime)
 	cache.Add("https://example.com", []byte("testdata"))
 
-	_, ok := cache.Get("https://example.com")
-	if !ok {
+	val := cache.Get("https://example.com")
+	if val == nil {
 		t.Errorf("expected to find key")
 		return
 	}
 
 	time.Sleep(waitTime)
 
-	_, ok = cache.Get("https://example.com")
-	if ok {
+	val = cache.Get("https://example.com")
+	if val != nil {
 		t.Errorf("expected to not find key")
 		return
 	}


### PR DESCRIPTION
1) Switched to *sync.RWMutex instead of sync.Mutex (we use pointers by the way)
2) Switched to stdlib context to utilize better-written functionality instead of home-brew implementation
3) Made Cache.Get() return nil if value is not found (current realization suppose to always have value cached or from api, so this change seems viable)
