### PR TITLE
enhancement(api, PokeCTX): custom errors and keys

### DIFF
--- a/internal/command/callbacks.go
+++ b/internal/command/callbacks.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -13,8 +14,7 @@ import (
 
 func ExitCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 	if len(arg) > 0 {
-		fmt.Println("Detected argument to help command which is not supported")
-		return "", nil
+		return "Detected argument to exit command which is not supported", nil
 	}
 	fmt.Println("\nIt's been a pleasure to have you onboard! Thanks for using this application")
 	os.Exit(0)
@@ -22,12 +22,11 @@ func ExitCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 }
 
 func MapCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
-	if len(arg) > 0 {
-		fmt.Println("Detected argument to map command which is not supported")
-		return "", nil
+	if len(arg) != 0 {
+		return "Detected argument to map command which is not supported", nil
 	}
 
-	apiOffset := pokectx.GetDefaultNum(ctx, 0, "api", "location", "offset")
+	apiOffset := pokectx.GetOrDefaultNum(ctx, 0, "api", "location", "offset")
 	apiOffset += 20
 	pokectx.SetNum(ctx, apiOffset, "api", "location", "offset")
 	endpoint := fmt.Sprintf("location-area?limit=20&offset=%d", apiOffset)
@@ -45,15 +44,14 @@ func MapCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 }
 
 func MapbCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
-	if len(arg) == 0 {
-		fmt.Println("Detected argument to map command which is not supported")
-		return "", nil
+	if len(arg) != 0 {
+		return "Detected argument to map command which is not supported", nil
 	}
 
-	apiOffset := pokectx.GetDefaultNum(ctx, 0, "api", "location", "offset")
+	apiOffset := pokectx.GetOrDefaultNum(ctx, 0, "api", "location", "offset")
 	apiOffset -= 20
 	pokectx.SetNum(ctx, apiOffset, "api", "location", "offset")
-	endpoint := fmt.Sprintf("location?limit=20&offset=%d", apiOffset)
+	endpoint := fmt.Sprintf("location-area?limit=20&offset=%d", apiOffset)
 
 	locations, err := api.Resource(endpoint)
 	if err != nil {
@@ -69,12 +67,16 @@ func MapbCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 
 func ExploreCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 	if len(arg) == 0 || strings.Contains(arg, " ") {
-		fmt.Println("You need to pass area-name as an argument to explore it.")
-		return "", nil
+		return "You need to pass area-name as an argument to explore it.", nil
 	}
 
 	locationArea, err := api.LocationArea(arg)
 	if err != nil {
+		if errors.Is(err, api.HTTPStatusError{}) {
+			if err.(api.HTTPStatusError).StatusCode == 404 {
+				return "Location Area not found: " + arg, nil
+			}
+		}
 		return "", err
 	}
 
@@ -96,15 +98,19 @@ func ExploreCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 }
 
 func CatchCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
-	if len(arg) == 0 || strings.Contains(arg, " ") {
-		fmt.Println("You need to pass pokemon name as an argument to catch it.")
-		return "", nil
+	if len(strings.Fields(arg)) != 1 {
+		return "This command requires an argument, virtually one.", nil
 	}
 
-	baseChance := 0.3 + rand.Float32()/2.0
+	baseChance := 0.4 + rand.Float32()/2.0
 
 	pokemon, err := api.Pokemon(arg)
 	if err != nil {
+		if errors.Is(err, api.HTTPStatusError{}) {
+			if err.(api.HTTPStatusError).StatusCode == 404 {
+				return "Pokemon not found: " + arg, nil
+			}
+		}
 		return "", err
 	}
 
@@ -112,14 +118,13 @@ func CatchCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 		return "Couldn't catch " + pokemon.Name + "... Try again!", nil
 	}
 
-	ctx.Set("pokedex", pokemon.Name)
+	ctx.SetKey("pokedex", pokemon.Name)
 	return "Congratulations! You've caught " + pokemon.Name + "!", nil
 }
 
 func InspectCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
-	if len(arg) == 0 || strings.Contains(arg, " ") {
-		fmt.Println("This command requires an argument, virtually one.")
-		return "", nil
+	if len(strings.Split(arg, "")) != 1 {
+		return "This command requires an argument, virtually one.", nil
 	}
 
 	caughtPokemons, _ := ctx.Get("pokedex")
@@ -158,7 +163,12 @@ func PokedexCallback(ctx *pokectx.Te4nickPokeCTX, arg string) (string, error) {
 		return "", nil
 	}
 
-	caughtPokemons, _ := ctx.Get("pokedex")
+	caughtPokemons, _ := ctx.GetKeys("pokedex")
 
-	return caughtPokemons, nil
+	msg := "Your Pokedex:\n"
+	for _, pokemonName := range caughtPokemons {
+		msg += "  - " + pokemonName + "\n"
+	}
+
+	return msg, nil
 }

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -46,7 +45,7 @@ func Fetch(endpoint string, out interface{}) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("abnormal response status code")
+		return HTTPStatusError{StatusCode: resp.StatusCode, URL: apiURL}
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/pkg/api/pokeerr.go
+++ b/pkg/api/pokeerr.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"fmt"
+)
+
+type HTTPStatusError struct {
+	StatusCode int
+	URL        string
+}
+
+func (e HTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP %s Status Code %d ", e.URL, e.StatusCode)
+}

--- a/pkg/pokectx/pokectx.go
+++ b/pkg/pokectx/pokectx.go
@@ -19,12 +19,38 @@ func New(path ...string) *Te4nickPokeCTX {
 	return ctx
 }
 
+// Set last provided string value to the path specified before it
+//
+// ctx.Set("my", "string", "value")
+//
+// ctx.Get("my", "string") // -> "value"
 func (ctx *Te4nickPokeCTX) Set(path ...string) {
 	ctx.root.set(path...)
 }
 
-func (ctx *Te4nickPokeCTX) Get(path ...string) (string, bool) {
+// Alias to Set(path, "")
+func (ctx *Te4nickPokeCTX) SetKey(path ...string) {
+	ctx.root.set(append(path, "")...)
+}
+
+// Get value by specified path
+//
+// ctx.Set("my", "string", "value")
+//
+// ctx.Get("my", "string") // -> "value"
+func (ctx *Te4nickPokeCTX) Get(path ...string) (value string, found bool) {
 	return ctx.root.get(path...)
+}
+
+// Get all available keys after specified path
+//
+// ctx.SetKey("my", "string", "value1")
+//
+// ctx.SetKey("my", "string", "value2")
+//
+// ctx.GetKeys("my", "string") // -> []string{"value1", "value2"}
+func (ctx *Te4nickPokeCTX) GetKeys(path ...string) (value []string, found bool) {
+	return ctx.root.getChildrenNames(path...)
 }
 
 type Ints interface {
@@ -43,7 +69,7 @@ type Number interface {
 	Ints | Uints | Floats
 }
 
-func GetDefaultNum[T Number](ctx *Te4nickPokeCTX, defaultVar T, path ...string) T {
+func GetOrDefaultNum[T Number](ctx *Te4nickPokeCTX, defaultVar T, path ...string) T {
 	s, found := ctx.Get(path...)
 	if !found {
 		return defaultVar

--- a/pkg/pokectx/tree.go
+++ b/pkg/pokectx/tree.go
@@ -26,7 +26,7 @@ func (n *te4nickNode) set(path ...string) {
 	child.set(path[1:]...)
 }
 
-func (n *te4nickNode) get(path ...string) (string, bool) {
+func (n *te4nickNode) get(path ...string) (value string, found bool) {
 	if len(path) == 0 {
 		return n.value, true
 	}
@@ -37,4 +37,20 @@ func (n *te4nickNode) get(path ...string) (string, bool) {
 	}
 
 	return child.get(path[1:]...)
+}
+
+func (n *te4nickNode) getChildrenNames(path ...string) (childrenNames []string, found bool) {
+	if len(path) == 0 {
+		for name := range n.children {
+			childrenNames = append(childrenNames, name)
+		}
+		return
+	}
+
+	child, ok := n.children[path[0]]
+	if !ok {
+		return nil, false
+	}
+
+	return child.getChildrenNames(path[1:]...)
 }


### PR DESCRIPTION
1) Added custom HTTP StatusCode error. Now one can check if error is raised by return code and make more flexible error handling.
2) Fixed  #18  and  #14  accordingly 
3) Enhanced PokeCTX with "Keys" methods allowing one to treat node children keys as return []string value. Also renamed GetDefault methods to GetOrDefault for more readability. Added comments to make things clear.